### PR TITLE
Workflow Patch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:
-        github_token: ${{ secrets.GIT_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist
         publish_branch: web  # Deploy to gh-pages branch


### PR DESCRIPTION
This pull request includes a small fix to the GitHub Actions workflow. The change updates the token used for deployment to use the correct secret.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L21-R21): Replaced `secrets.GIT_TOKEN` with `secrets.GITHUB_TOKEN` in the `github_token` field to ensure the deployment action functions correctly.